### PR TITLE
Accept cluster flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,15 @@ the AWS SDK for Go documentation.
 - [Load Balancers](#load-balancers)
 - [Certificates](#certificates)
 
+#### Global Flags
+
+| Flag | Default | Description |
+| --- | --- | --- |
+| --cluster | fargate | ECS cluster to use for tasks and services. If omitted, a cluster named "fargate" will be created. |
+| --region | us-east-1 | AWS Region to run commands against. The only valid Region is currently us-east-1. |
+| --no-color | false | Disable ANSI color output. |
+| --verbose | false | Enable debugging output. |
+
 #### Tasks
 
 Tasks are one-time executions of your container. Instances of your task are run

--- a/cmd/lb_info.go
+++ b/cmd/lb_info.go
@@ -38,7 +38,7 @@ func init() {
 func getLoadBalancerInfo(operation *LbInfoOperation) {
 	elbv2 := ELBV2.New(sess)
 	acm := ACM.New(sess)
-	ecs := ECS.New(sess)
+	ecs := ECS.New(sess, clusterName)
 	loadBalancer := elbv2.DescribeLoadBalancer(operation.LoadBalancerName)
 	services := ecs.ListServices()
 

--- a/cmd/service_create.go
+++ b/cmd/service_create.go
@@ -231,7 +231,7 @@ func createService(operation *ServiceCreateOperation) {
 	cwl := CWL.New(sess)
 	ec2 := EC2.New(sess)
 	ecr := ECR.New(sess)
-	ecs := ECS.New(sess)
+	ecs := ECS.New(sess, clusterName)
 	iam := IAM.New(sess)
 
 	var (

--- a/cmd/service_deploy.go
+++ b/cmd/service_deploy.go
@@ -45,7 +45,7 @@ func init() {
 }
 
 func deployService(operation *ServiceDeployOperation) {
-	ecs := ECS.New(sess)
+	ecs := ECS.New(sess, clusterName)
 	service := ecs.DescribeService(operation.ServiceName)
 
 	if operation.Image == "" {

--- a/cmd/service_destroy.go
+++ b/cmd/service_destroy.go
@@ -31,7 +31,8 @@ func init() {
 }
 
 func destroyService(operation *ServiceDestroyOperation) {
-	ecs := ECS.New(sess)
+	ecs := ECS.New(sess, clusterName)
+
 	ecs.DestroyService(operation.ServiceName)
 	console.Info("Destroyed service %s", operation.ServiceName)
 }

--- a/cmd/service_env_list.go
+++ b/cmd/service_env_list.go
@@ -27,7 +27,7 @@ func init() {
 }
 
 func serviceEnvList(operation *ServiceEnvListOperation) {
-	ecs := ECS.New(sess)
+	ecs := ECS.New(sess, clusterName)
 	service := ecs.DescribeService(operation.ServiceName)
 	envVars := ecs.GetEnvVarsFromTaskDefinition(service.TaskDefinitionArn)
 

--- a/cmd/service_env_set.go
+++ b/cmd/service_env_set.go
@@ -33,7 +33,6 @@ At least one environment variable must be specified via the --env flag. Specify
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ServiceEnvSetOperation{
 			ServiceName: args[0],
-			EnvVars:     envVars,
 		}
 
 		operation.SetEnvVars(flagServiceEnvSetEnvVars)
@@ -49,7 +48,7 @@ func init() {
 }
 
 func serviceEnvSet(operation *ServiceEnvSetOperation) {
-	ecs := ECS.New(sess)
+	ecs := ECS.New(sess, clusterName)
 	service := ecs.DescribeService(operation.ServiceName)
 	taskDefinitionArn := ecs.AddEnvVarsToTaskDefinition(service.TaskDefinitionArn, operation.EnvVars)
 

--- a/cmd/service_env_unset.go
+++ b/cmd/service_env_unset.go
@@ -51,7 +51,7 @@ func init() {
 }
 
 func serviceEnvUnset(operation *ServiceEnvUnsetOperation) {
-	ecs := ECS.New(sess)
+	ecs := ECS.New(sess, clusterName)
 	service := ecs.DescribeService(operation.ServiceName)
 	taskDefinitionArn := ecs.RemoveEnvVarsFromTaskDefinition(service.TaskDefinitionArn, operation.Keys)
 

--- a/cmd/service_info.go
+++ b/cmd/service_info.go
@@ -48,7 +48,7 @@ func getServiceInfo(operation *ServiceInfoOperation) {
 	var eniIds []string
 
 	acm := ACM.New(sess)
-	ecs := ECS.New(sess)
+	ecs := ECS.New(sess, clusterName)
 	ec2 := EC2.New(sess)
 	elbv2 := ELBV2.New(sess)
 	service := ecs.DescribeService(operation.ServiceName)

--- a/cmd/service_list.go
+++ b/cmd/service_list.go
@@ -30,7 +30,7 @@ func listServices() {
 	targetGroups := make(map[string]ELBV2.TargetGroup)
 	loadBalancers := make(map[string]ELBV2.LoadBalancer)
 
-	ecs := ECS.New(sess)
+	ecs := ECS.New(sess, clusterName)
 	elbv2 := ELBV2.New(sess)
 	services := ecs.ListServices()
 

--- a/cmd/service_ps.go
+++ b/cmd/service_ps.go
@@ -36,7 +36,7 @@ func init() {
 func getServiceProcessList(operation *ServiceProcessListOperation) {
 	var eniIds []string
 
-	ecs := ECS.New(sess)
+	ecs := ECS.New(sess, clusterName)
 	ec2 := EC2.New(sess)
 	tasks := ecs.DescribeTasksForService(operation.ServiceName)
 

--- a/cmd/service_restart.go
+++ b/cmd/service_restart.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 func restartService(operation *ServiceRestartOperation) {
-	ecs := ECS.New(sess)
+	ecs := ECS.New(sess, clusterName)
 	service := ecs.DescribeService(operation.ServiceName)
 	taskDefinitionArn := ecs.IncrementTaskDefinition(service.TaskDefinitionArn)
 

--- a/cmd/service_scale.go
+++ b/cmd/service_scale.go
@@ -15,10 +15,10 @@ const validScalePattern = "[-\\+]?[0-9]+"
 type ScaleServiceOperation struct {
 	ServiceName  string
 	DesiredCount int64
-	Ecs          ECS.ECS
 }
 
 func (o *ScaleServiceOperation) SetScale(scaleExpression string) {
+	ecs := ECS.New(sess, clusterName)
 	validScale := regexp.MustCompile(validScalePattern)
 
 	if !validScale.MatchString(scaleExpression) {
@@ -27,7 +27,7 @@ func (o *ScaleServiceOperation) SetScale(scaleExpression string) {
 
 	if scaleExpression[0] == '+' || scaleExpression[0] == '-' {
 		if s, err := strconv.ParseInt(scaleExpression[1:len(scaleExpression)], 10, 64); err == nil {
-			currentDesiredCount := o.Ecs.GetDesiredCount(o.ServiceName)
+			currentDesiredCount := ecs.GetDesiredCount(o.ServiceName)
 			if scaleExpression[0] == '+' {
 				o.DesiredCount = currentDesiredCount + s
 			} else if scaleExpression[0] == '-' {
@@ -57,7 +57,6 @@ specified with a sign such as +5 or -2.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ScaleServiceOperation{
 			ServiceName: args[0],
-			Ecs:         ECS.New(sess),
 		}
 
 		operation.SetScale(args[1])
@@ -71,6 +70,8 @@ func init() {
 }
 
 func scaleService(operation *ScaleServiceOperation) {
-	operation.Ecs.SetDesiredCount(operation.ServiceName, operation.DesiredCount)
+	ecs := ECS.New(sess, clusterName)
+
+	ecs.SetDesiredCount(operation.ServiceName, operation.DesiredCount)
 	console.Info("Scaled service %s to %d", operation.ServiceName, operation.DesiredCount)
 }

--- a/cmd/service_update.go
+++ b/cmd/service_update.go
@@ -12,17 +12,18 @@ type ServiceUpdateOperation struct {
 	ServiceName string
 	Cpu         string
 	Memory      string
-	Ecs         ECS.ECS
 	Service     ECS.Service
 }
 
 func (o *ServiceUpdateOperation) Validate() {
+	ecs := ECS.New(sess, clusterName)
+
 	if o.Cpu == "" && o.Memory == "" {
 		console.ErrorExit(fmt.Errorf("--cpu and/or --memory must be supplied"), "Invalid command line arguments")
 	}
 
-	o.Service = o.Ecs.DescribeService(o.ServiceName)
-	cpu, memory := o.Ecs.GetCpuAndMemoryFromTaskDefinition(o.Service.TaskDefinitionArn)
+	o.Service = ecs.DescribeService(o.ServiceName)
+	cpu, memory := ecs.GetCpuAndMemoryFromTaskDefinition(o.Service.TaskDefinitionArn)
 
 	if o.Cpu == "" {
 		o.Cpu = cpu
@@ -83,13 +84,14 @@ func init() {
 }
 
 func updateService(operation *ServiceUpdateOperation) {
-	newTaskDefinitionArn := operation.Ecs.UpdateTaskDefinitionCpuAndMemory(
+	ecs := ECS.New(sess, clusterName)
+
+	newTaskDefinitionArn := ecs.UpdateTaskDefinitionCpuAndMemory(
 		operation.Service.TaskDefinitionArn,
 		operation.Cpu,
 		operation.Memory,
 	)
 
-	operation.Ecs.UpdateServiceTaskDefinition(operation.ServiceName, newTaskDefinitionArn)
+	ecs.UpdateServiceTaskDefinition(operation.ServiceName, newTaskDefinitionArn)
 	console.Info("Updated service %s to %d CPU units / %d MiB", operation.ServiceName, operation.Cpu, operation.Memory)
-
 }

--- a/cmd/task_info.go
+++ b/cmd/task_info.go
@@ -48,7 +48,7 @@ func getTaskInfo(operation *TaskInfoOperation) {
 	var tasks []ECS.Task
 	var eniIds []string
 
-	ecs := ECS.New(sess)
+	ecs := ECS.New(sess, clusterName)
 	ec2 := EC2.New(sess)
 
 	if len(operation.TaskIds) > 0 {

--- a/cmd/task_list.go
+++ b/cmd/task_list.go
@@ -23,7 +23,7 @@ func init() {
 }
 
 func listTaskGroups() {
-	ecs := ECS.New(sess)
+	ecs := ECS.New(sess, clusterName)
 	taskGroups := ecs.ListTaskGroups()
 
 	if len(taskGroups) == 0 {

--- a/cmd/task_ps.go
+++ b/cmd/task_ps.go
@@ -36,7 +36,7 @@ func init() {
 func getTaskProcessList(operation *TaskProcessListOperation) {
 	var eniIds []string
 
-	ecs := ECS.New(sess)
+	ecs := ECS.New(sess, clusterName)
 	ec2 := EC2.New(sess)
 	tasks := ecs.DescribeTasksForTaskGroup(operation.TaskName)
 

--- a/cmd/task_run.go
+++ b/cmd/task_run.go
@@ -116,7 +116,7 @@ func runTask(operation *TaskRunOperation) {
 	cwl := CWL.New(sess)
 	ec2 := EC2.New(sess)
 	ecr := ECR.New(sess)
-	ecs := ECS.New(sess)
+	ecs := ECS.New(sess, clusterName)
 	iam := IAM.New(sess)
 
 	if ecr.IsRepositoryCreated(operation.TaskName) {

--- a/cmd/task_stop.go
+++ b/cmd/task_stop.go
@@ -43,7 +43,7 @@ func init() {
 func stopTasks(operation *TaskStopOperation) {
 	var taskCount int
 
-	ecs := ECS.New(sess)
+	ecs := ECS.New(sess, clusterName)
 
 	if len(operation.TaskIds) > 0 {
 		taskCount = len(operation.TaskIds)

--- a/ecs/cluster.go
+++ b/ecs/cluster.go
@@ -6,14 +6,12 @@ import (
 	"github.com/jpignata/fargate/console"
 )
 
-const clusterName = "fargate"
-
 func (ecs *ECS) CreateCluster() error {
 	console.Debug("Creating ECS cluster")
 
 	_, err := ecs.svc.CreateCluster(
 		&awsecs.CreateClusterInput{
-			ClusterName: aws.String(clusterName),
+			ClusterName: aws.String(ecs.ClusterName),
 		},
 	)
 
@@ -21,7 +19,7 @@ func (ecs *ECS) CreateCluster() error {
 		return err
 	}
 
-	console.Debug("Created ECS cluster %s", clusterName)
+	console.Debug("Created ECS cluster %s", ecs.ClusterName)
 
 	return nil
 }

--- a/ecs/main.go
+++ b/ecs/main.go
@@ -6,12 +6,13 @@ import (
 )
 
 type ECS struct {
-	svc  *ecs.ECS
-	sess *session.Session
+	svc         *ecs.ECS
+	ClusterName string
 }
 
-func New(sess *session.Session) ECS {
+func New(sess *session.Session, clusterName string) ECS {
 	return ECS{
-		svc: ecs.New(sess),
+		ClusterName: clusterName,
+		svc:         ecs.New(sess),
 	}
 }

--- a/ecs/service.go
+++ b/ecs/service.go
@@ -118,7 +118,7 @@ func (ecs *ECS) GetDesiredCount(serviceName string) int64 {
 func (ecs *ECS) SetDesiredCount(serviceName string, desiredCount int64) {
 	_, err := ecs.svc.UpdateService(
 		&awsecs.UpdateServiceInput{
-			Cluster:      aws.String(clusterName),
+			Cluster:      aws.String(ecs.ClusterName),
 			Service:      aws.String(serviceName),
 			DesiredCount: aws.Int64(desiredCount),
 		},
@@ -132,7 +132,7 @@ func (ecs *ECS) SetDesiredCount(serviceName string, desiredCount int64) {
 func (ecs *ECS) DestroyService(serviceName string) {
 	_, err := ecs.svc.DeleteService(
 		&awsecs.DeleteServiceInput{
-			Cluster: aws.String(clusterName),
+			Cluster: aws.String(ecs.ClusterName),
 			Service: aws.String(serviceName),
 		},
 	)
@@ -148,7 +148,7 @@ func (ecs *ECS) ListServices() []Service {
 
 	err := ecs.svc.ListServicesPages(
 		&awsecs.ListServicesInput{
-			Cluster:    aws.String(clusterName),
+			Cluster:    aws.String(ecs.ClusterName),
 			LaunchType: aws.String(awsecs.CompatibilityFargate),
 		},
 
@@ -181,7 +181,7 @@ func (ecs *ECS) DescribeServices(serviceArns []string) []Service {
 
 	resp, err := ecs.svc.DescribeServices(
 		&awsecs.DescribeServicesInput{
-			Cluster:  aws.String(clusterName),
+			Cluster:  aws.String(ecs.ClusterName),
 			Services: aws.StringSlice(serviceArns),
 		},
 	)
@@ -256,7 +256,7 @@ func (ecs *ECS) DescribeServices(serviceArns []string) []Service {
 func (ecs *ECS) UpdateServiceTaskDefinition(serviceName, taskDefinitionArn string) {
 	_, err := ecs.svc.UpdateService(
 		&awsecs.UpdateServiceInput{
-			Cluster:        aws.String(clusterName),
+			Cluster:        aws.String(ecs.ClusterName),
 			Service:        aws.String(serviceName),
 			TaskDefinition: aws.String(taskDefinitionArn),
 		},

--- a/ecs/task.go
+++ b/ecs/task.go
@@ -75,7 +75,7 @@ func (ecs *ECS) RunTask(i *RunTaskInput) {
 func (ecs *ECS) DescribeTasksForService(serviceName string) []Task {
 	return ecs.listTasks(
 		&awsecs.ListTasksInput{
-			Cluster:     aws.String(clusterName),
+			Cluster:     aws.String(ecs.ClusterName),
 			LaunchType:  aws.String(awsecs.CompatibilityFargate),
 			ServiceName: aws.String(serviceName),
 		},
@@ -86,7 +86,7 @@ func (ecs *ECS) DescribeTasksForTaskGroup(taskGroupName string) []Task {
 	return ecs.listTasks(
 		&awsecs.ListTasksInput{
 			StartedBy: aws.String(fmt.Sprintf(startedByFormat, taskGroupName)),
-			Cluster:   aws.String(clusterName),
+			Cluster:   aws.String(ecs.ClusterName),
 		},
 	)
 }
@@ -97,7 +97,7 @@ func (ecs *ECS) ListTaskGroups() []*TaskGroup {
 	taskGroupStartedByRegexp := regexp.MustCompile(taskGroupStartedByPattern)
 
 	input := &awsecs.ListTasksInput{
-		Cluster: aws.String(clusterName),
+		Cluster: aws.String(ecs.ClusterName),
 	}
 
 OUTER:
@@ -136,7 +136,7 @@ func (ecs *ECS) StopTasks(taskIds []string) {
 func (ecs *ECS) StopTask(taskId string) {
 	_, err := ecs.svc.StopTask(
 		&awsecs.StopTaskInput{
-			Cluster: aws.String(clusterName),
+			Cluster: aws.String(ecs.ClusterName),
 			Task:    aws.String(taskId),
 		},
 	)
@@ -185,7 +185,7 @@ func (ecs *ECS) DescribeTasks(taskIds []string) []Task {
 
 	resp, err := ecs.svc.DescribeTasks(
 		&awsecs.DescribeTasksInput{
-			Cluster: aws.String(clusterName),
+			Cluster: aws.String(ecs.ClusterName),
 			Tasks:   aws.StringSlice(taskIds),
 		},
 	)


### PR DESCRIPTION
 Accept --cluster flag

For users that may be running Fargate services across multiple ECS clusters, accept a --cluster flag. Users don't have to use this and fargate will continue using a cluster called "fargate" without prompting.

- Use Credentials.Get() as a pre-flight check
- Document global flags in README
- Remove vestigial EnvVar-related vars
- Match cobra's default flag output in usage
-  Hoist noColor check up in root's PersistentPreRun