### PR TITLE
Add networking flags to `fargate lb create`

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ List load balancers
 
 ```console
 fargate lb create <load-balancer-name> --port <port-expression> [--certificate <certificate-name>]
-                                       [--security-group-id <security-group-id>]
+                                       [--subnet-id <subnet-id>] [--security-group-id <security-group-id>]
 ```
 
 Create a load balancer
@@ -463,6 +463,13 @@ You can optionally include certificates to secure HTTPS ports by passed the
 multiple times to add additional certificates to a single load balancer which
 uses Service Name Identification (SNI) to select the appropriate certificate
 for the request.
+
+By default, the load balancer will be created in the default VPC and attached
+to the default VPC subnets for each availability zone. You can override this by
+specifying explicit subnets by passing the --subnet-id flag with a subnet ID.
+HTTP/HTTPS load balancers require at least two subnets attached while a TCP
+load balancer requires only one. You may only specify a single subnet from each
+availability zone.
 
 Security groups can optionally be specified for HTTP/HTTPS load balancers by
 passing the --security-group-id flag with a security group ID. To add multiple

--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ List load balancers
 
 ```console
 fargate lb create <load-balancer-name> --port <port-expression> [--certificate <certificate-name>]
+                                       [--security-group-id <security-group-id>]
 ```
 
 Create a load balancer
@@ -462,6 +463,12 @@ You can optionally include certificates to secure HTTPS ports by passed the
 multiple times to add additional certificates to a single load balancer which
 uses Service Name Identification (SNI) to select the appropriate certificate
 for the request.
+
+Security groups can optionally be specified for HTTP/HTTPS load balancers by
+passing the --security-group-id flag with a security group ID. To add multiple
+security groups, pass --security-group-id with a security group ID multiple
+times. If --security-group-id is omitted, a permissive security group will be
+applied to the load balancer.
 
 ##### fargate lb destroy
 

--- a/cmd/lb_info.go
+++ b/cmd/lb_info.go
@@ -46,6 +46,7 @@ func getLoadBalancerInfo(operation *LbInfoOperation) {
 	console.KeyValue("Status", "%s\n", util.Humanize(loadBalancer.State))
 	console.KeyValue("Type", "%s\n", util.Humanize(loadBalancer.Type))
 	console.KeyValue("DNS Name", "%s\n", loadBalancer.DNSName)
+	console.KeyValue("Security Groups", "%s\n", strings.Join(loadBalancer.SecurityGroupIds, ", "))
 	console.KeyValue("Listeners", "\n")
 
 	for _, listener := range elbv2.GetListeners(loadBalancer.Arn) {

--- a/cmd/lb_info.go
+++ b/cmd/lb_info.go
@@ -46,6 +46,7 @@ func getLoadBalancerInfo(operation *LbInfoOperation) {
 	console.KeyValue("Status", "%s\n", util.Humanize(loadBalancer.State))
 	console.KeyValue("Type", "%s\n", util.Humanize(loadBalancer.Type))
 	console.KeyValue("DNS Name", "%s\n", loadBalancer.DNSName)
+	console.KeyValue("Subnets", "%s\n", strings.Join(loadBalancer.SubnetIds, ", "))
 	console.KeyValue("Security Groups", "%s\n", strings.Join(loadBalancer.SecurityGroupIds, ", "))
 	console.KeyValue("Listeners", "\n")
 

--- a/elbv2/load_balancer.go
+++ b/elbv2/load_balancer.go
@@ -17,6 +17,7 @@ type LoadBalancer struct {
 	Type             string
 	HostedZoneId     string
 	SecurityGroupIds []string
+	SubnetIds        []string
 }
 
 type DescribeLoadBalancersInput struct {
@@ -110,6 +111,12 @@ func (elbv2 *ELBV2) DescribeLoadBalancers(i DescribeLoadBalancersInput) []LoadBa
 		input,
 		func(resp *awselbv2.DescribeLoadBalancersOutput, lastPage bool) bool {
 			for _, loadBalancer := range resp.LoadBalancers {
+				var subnetIds []string
+
+				for _, availabilityZone := range loadBalancer.AvailabilityZones {
+					subnetIds = append(subnetIds, aws.StringValue(availabilityZone.SubnetId))
+				}
+
 				loadBalancers = append(loadBalancers,
 					LoadBalancer{
 						Arn:              aws.StringValue(loadBalancer.LoadBalancerArn),
@@ -119,6 +126,7 @@ func (elbv2 *ELBV2) DescribeLoadBalancers(i DescribeLoadBalancersInput) []LoadBa
 						SecurityGroupIds: aws.StringValueSlice(loadBalancer.SecurityGroups),
 						State:            aws.StringValue(loadBalancer.State.Code),
 						StateReason:      aws.StringValue(loadBalancer.State.Reason),
+						SubnetIds:        subnetIds,
 						Type:             aws.StringValue(loadBalancer.Type),
 					},
 				)

--- a/elbv2/load_balancer.go
+++ b/elbv2/load_balancer.go
@@ -9,13 +9,14 @@ import (
 )
 
 type LoadBalancer struct {
-	DNSName      string
-	Name         string
-	State        string
-	StateReason  string
-	Arn          string
-	Type         string
-	HostedZoneId string
+	DNSName          string
+	Name             string
+	State            string
+	StateReason      string
+	Arn              string
+	Type             string
+	HostedZoneId     string
+	SecurityGroupIds []string
 }
 
 type DescribeLoadBalancersInput struct {
@@ -111,13 +112,14 @@ func (elbv2 *ELBV2) DescribeLoadBalancers(i DescribeLoadBalancersInput) []LoadBa
 			for _, loadBalancer := range resp.LoadBalancers {
 				loadBalancers = append(loadBalancers,
 					LoadBalancer{
-						Name:         aws.StringValue(loadBalancer.LoadBalancerName),
-						DNSName:      aws.StringValue(loadBalancer.DNSName),
-						State:        aws.StringValue(loadBalancer.State.Code),
-						StateReason:  aws.StringValue(loadBalancer.State.Reason),
-						Arn:          aws.StringValue(loadBalancer.LoadBalancerArn),
-						Type:         aws.StringValue(loadBalancer.Type),
-						HostedZoneId: aws.StringValue(loadBalancer.CanonicalHostedZoneId),
+						Arn:              aws.StringValue(loadBalancer.LoadBalancerArn),
+						DNSName:          aws.StringValue(loadBalancer.DNSName),
+						HostedZoneId:     aws.StringValue(loadBalancer.CanonicalHostedZoneId),
+						Name:             aws.StringValue(loadBalancer.LoadBalancerName),
+						SecurityGroupIds: aws.StringValueSlice(loadBalancer.SecurityGroups),
+						State:            aws.StringValue(loadBalancer.State.Code),
+						StateReason:      aws.StringValue(loadBalancer.State.Reason),
+						Type:             aws.StringValue(loadBalancer.Type),
 					},
 				)
 			}

--- a/elbv2/load_balancer.go
+++ b/elbv2/load_balancer.go
@@ -24,10 +24,10 @@ type DescribeLoadBalancersInput struct {
 }
 
 type CreateLoadBalancerInput struct {
-	Name            string
-	SubnetIds       []string
-	Type            string
-	SecurityGroupId string
+	Name             string
+	SubnetIds        []string
+	Type             string
+	SecurityGroupIds []string
 }
 
 func (elbv2 *ELBV2) CreateLoadBalancer(i *CreateLoadBalancerInput) string {
@@ -39,7 +39,7 @@ func (elbv2 *ELBV2) CreateLoadBalancer(i *CreateLoadBalancerInput) string {
 	}
 
 	if i.Type == awselbv2.LoadBalancerTypeEnumApplication {
-		input.SetSecurityGroups(aws.StringSlice([]string{i.SecurityGroupId}))
+		input.SetSecurityGroups(aws.StringSlice(i.SecurityGroupIds))
 	}
 
 	resp, err := elbv2.svc.CreateLoadBalancer(input)


### PR DESCRIPTION
Expert users want the ability to use different VPCs for different services. This pull is the first step in that direction by giving the ability to put load balancers in specific subnets (and as a result, VPCs) and apply specific security groups to them. Omitting these options results in the current behavior where load balancers are placed in the default VPC with a permissive security group