### PR TITLE
Add networking flags to service and task commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,12 @@ Specify the desired count of tasks the service should maintain by passing the
 --num flag with a number. If you omit this flag, fargate will configure a
 service with a desired number of tasks of 1.
 
+Security groups can optionally be specified for the service by passing the
+--security-group-id flag with a security group ID. To add multiple security
+groups, pass --security-group-id with a security group ID multiple times. If
+--security-group-id is omitted, a permissive security group will be applied to
+the service.
+
 ##### fargate service deploy
 
 ```console

--- a/README.md
+++ b/README.md
@@ -113,6 +113,16 @@ commit. If not, a timestamp in the format of YYYYMMDDHHMMSS will be used.
 Environment variables can be specified via the --env flag. Specify --env with a
 key=value parameter multiple times to add multiple variables.
 
+Security groups can optionally be specified for the task by passing the
+--security-group-id flag with a security group ID. To add multiple security
+groups, pass --security-group-id with a security group ID multiple times. If
+--security-group-id is omitted, a permissive security group will be applied to
+the task.
+
+By default, the task will be created in the default VPC and attached to the
+default VPC subnets for each availability zone. You can override this by
+specifying explicit subnets by passing the --subnet-id flag with a subnet ID.
+
 ##### fargate task info
 
 ```console

--- a/README.md
+++ b/README.md
@@ -254,7 +254,8 @@ specifying the --rule flag along with a rule expression. Rule expressions are
 in the format of TYPE=VALUE. Type can either be PATH or HOST. PATH matches the
 PATH of the request and HOST matches the requested hostname in the HTTP
 request. Both PATH and HOST types can include up to three wildcard characters:
-\* to match multiple characters and ? to match a single character.
+\* to match multiple characters and ? to match a single character. If rules are
+omitted, the service will be the load balancer's default action.
 
 Environment variables can be specified via the --env flag. Specify --env with a
 key=value parameter multiple times to add multiple variables.
@@ -268,6 +269,10 @@ Security groups can optionally be specified for the service by passing the
 groups, pass --security-group-id with a security group ID multiple times. If
 --security-group-id is omitted, a permissive security group will be applied to
 the service.
+
+By default, the service will be created in the default VPC and attached
+to the default VPC subnets for each availability zone. You can override this by
+specifying explicit subnets by passing the --subnet-id flag with a subnet ID.
 
 ##### fargate service deploy
 

--- a/cmd/lb_create.go
+++ b/cmd/lb_create.go
@@ -184,7 +184,7 @@ func init() {
 	lbCreateCmd.Flags().StringSliceVarP(&flagLbCreateCertificates, "certificate", "c", []string{}, "Name of certificate to add (can be specified multiple times)")
 	lbCreateCmd.Flags().StringSliceVarP(&flagLbCreatePorts, "port", "p", []string{}, "Port to listen on [e.g., 80, 443, http:8080, https:8443, tcp:1935] (can be specified multiple times)")
 	lbCreateCmd.Flags().StringSliceVar(&flagLbCreateSecurityGroupIds, "security-group-id", []string{}, "ID of a security group to apply to the load balancer (can be specified multiple times)")
-	lbCreateCmd.Flags().StringSliceVar(&flagLbCreateSubnetIds, "subnet-id", []string{}, "ID of a subnet to attach to the load balancer (can be specified multiple times)")
+	lbCreateCmd.Flags().StringSliceVar(&flagLbCreateSubnetIds, "subnet-id", []string{}, "ID of a subnet to place the load balancer (can be specified multiple times)")
 
 	lbCmd.AddCommand(lbCreateCmd)
 }

--- a/cmd/lb_create.go
+++ b/cmd/lb_create.go
@@ -14,13 +14,8 @@ import (
 )
 
 const (
-	typeApplication string = "application"
-	typeNetwork     string = "network"
-	protocolHttp    string = "HTTP"
-	protocolHttps   string = "HTTPS"
-	protocolTcp     string = "TCP"
-	minPort         int64  = 1
-	maxPort         int64  = 65535
+	minPort int64 = 1
+	maxPort int64 = 65535
 )
 
 type LbCreateOperation struct {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,9 +21,13 @@ const (
 	defaultClusterName = "fargate"
 	defaultRegion      = "us-east-1"
 
-	cpuUnitsInVCpu        = 1024
-	mebibytesInGibibyte   = 1024
-	validProtocolsPattern = "(?i)\\ATCP|HTTP(S)?\\z"
+	typeApplication       string = "application"
+	typeNetwork           string = "network"
+	protocolHttp          string = "HTTP"
+	protocolHttps         string = "HTTPS"
+	protocolTcp           string = "TCP"
+	mebibytesInGibibyte   int64  = 1024
+	validProtocolsPattern string = "(?i)\\ATCP|HTTP(S)?\\z"
 )
 
 var InvalidCpuAndMemoryCombination = fmt.Errorf(`Invalid CPU and Memory settings

--- a/cmd/service_info.go
+++ b/cmd/service_info.go
@@ -62,6 +62,7 @@ func getServiceInfo(operation *ServiceInfoOperation) {
 	console.KeyValue("Image", "%s\n", service.Image)
 	console.KeyValue("Cpu", "%s\n", service.Cpu)
 	console.KeyValue("Memory", "%s\n", service.Memory)
+	console.KeyValue("Security Groups", "%s\n", strings.Join(service.SecurityGroupIds, ", "))
 
 	if service.TargetGroupArn != "" {
 		loadBalancerArn := elbv2.GetTargetGroupLoadBalancerArn(service.TargetGroupArn)

--- a/cmd/service_info.go
+++ b/cmd/service_info.go
@@ -62,8 +62,8 @@ func getServiceInfo(operation *ServiceInfoOperation) {
 	console.KeyValue("Image", "%s\n", service.Image)
 	console.KeyValue("Cpu", "%s\n", service.Cpu)
 	console.KeyValue("Memory", "%s\n", service.Memory)
-	console.KeyValue("Security Groups", "%s\n", strings.Join(service.SecurityGroupIds, ", "))
 	console.KeyValue("Subnets", "%s\n", strings.Join(service.SubnetIds, ", "))
+	console.KeyValue("Security Groups", "%s\n", strings.Join(service.SecurityGroupIds, ", "))
 
 	if service.TargetGroupArn != "" {
 		loadBalancerArn := elbv2.GetTargetGroupLoadBalancerArn(service.TargetGroupArn)

--- a/cmd/service_info.go
+++ b/cmd/service_info.go
@@ -63,6 +63,7 @@ func getServiceInfo(operation *ServiceInfoOperation) {
 	console.KeyValue("Cpu", "%s\n", service.Cpu)
 	console.KeyValue("Memory", "%s\n", service.Memory)
 	console.KeyValue("Security Groups", "%s\n", strings.Join(service.SecurityGroupIds, ", "))
+	console.KeyValue("Subnets", "%s\n", strings.Join(service.SubnetIds, ", "))
 
 	if service.TargetGroupArn != "" {
 		loadBalancerArn := elbv2.GetTargetGroupLoadBalancerArn(service.TargetGroupArn)

--- a/cmd/service_ps.go
+++ b/cmd/service_ps.go
@@ -51,10 +51,10 @@ func getServiceProcessList(operation *ServiceProcessListOperation) {
 
 		w := new(tabwriter.Writer)
 		w.Init(os.Stdout, 0, 8, 1, '\t', 0)
-		fmt.Fprintln(w, "ID\tIMAGE\tSTATUS\tRUNNING\tIP\tCPU\tMEMORY\tDEPLOYMENT\t")
+		fmt.Fprintln(w, "ID\tIMAGE\tSTATUS\tRUNNING\tIP\tCPU\tMEMORY\t")
 
 		for _, t := range tasks {
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 				t.TaskId,
 				t.Image,
 				util.Humanize(t.LastStatus),
@@ -62,7 +62,6 @@ func getServiceProcessList(operation *ServiceProcessListOperation) {
 				enis[t.EniId].PublicIpAddress,
 				t.Cpu,
 				t.Memory,
-				t.DeploymentId,
 			)
 		}
 

--- a/cmd/task_info.go
+++ b/cmd/task_info.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/jpignata/fargate/console"
 	EC2 "github.com/jpignata/fargate/ec2"
@@ -73,13 +74,17 @@ func getTaskInfo(operation *TaskInfoOperation) {
 	console.KeyValue("Task Instances", "%d\n", len(tasks))
 
 	for _, task := range tasks {
+		eni := enis[task.EniId]
+
 		console.KeyValue("  "+task.TaskId, "\n")
 		console.KeyValue("    Image", "%s\n", task.Image)
 		console.KeyValue("    Status", "%s\n", util.Humanize(task.LastStatus))
 		console.KeyValue("    Started At", "%s\n", task.CreatedAt)
-		console.KeyValue("    IP", "%s\n", enis[task.EniId].PublicIpAddress)
+		console.KeyValue("    IP", "%s\n", eni.PublicIpAddress)
 		console.KeyValue("    CPU", "%s\n", task.Cpu)
 		console.KeyValue("    Memory", "%s\n", task.Memory)
+		console.KeyValue("    Subnet", "%s\n", task.SubnetId)
+		console.KeyValue("    Security Groups", "%s\n", strings.Join(eni.SecurityGroupIds, ", "))
 
 		if len(task.EnvVars) > 0 {
 			console.KeyValue("    Environment Variables", "\n")

--- a/ec2/eni.go
+++ b/ec2/eni.go
@@ -7,8 +7,9 @@ import (
 )
 
 type Eni struct {
-	PublicIpAddress string
-	EniId           string
+	PublicIpAddress  string
+	EniId            string
+	SecurityGroupIds []string
 }
 
 func (ec2 *EC2) DescribeNetworkInterfaces(eniIds []string) map[string]Eni {
@@ -25,10 +26,17 @@ func (ec2 *EC2) DescribeNetworkInterfaces(eniIds []string) map[string]Eni {
 	}
 
 	for _, e := range resp.NetworkInterfaces {
+		var securityGroupIds []*string
+
+		for _, group := range e.Groups {
+			securityGroupIds = append(securityGroupIds, group.GroupId)
+		}
+
 		if e.Association != nil {
 			eni := Eni{
-				EniId:           aws.StringValue(e.NetworkInterfaceId),
-				PublicIpAddress: aws.StringValue(e.Association.PublicIp),
+				EniId:            aws.StringValue(e.NetworkInterfaceId),
+				PublicIpAddress:  aws.StringValue(e.Association.PublicIp),
+				SecurityGroupIds: aws.StringValueSlice(securityGroupIds),
 			}
 
 			enis[eni.EniId] = eni

--- a/ecs/service.go
+++ b/ecs/service.go
@@ -14,10 +14,10 @@ type CreateServiceInput struct {
 	DesiredCount      int64
 	Name              string
 	Port              int64
+	SecurityGroupIds  []string
 	SubnetIds         []string
 	TargetGroupArn    string
 	TaskDefinitionArn string
-	SecurityGroupId   string
 }
 
 type Service struct {
@@ -72,7 +72,7 @@ func (ecs *ECS) CreateService(input *CreateServiceInput) {
 			AwsvpcConfiguration: &awsecs.AwsVpcConfiguration{
 				AssignPublicIp: aws.String(awsecs.AssignPublicIpEnabled),
 				Subnets:        aws.StringSlice(input.SubnetIds),
-				SecurityGroups: aws.StringSlice([]string{input.SecurityGroupId}),
+				SecurityGroups: aws.StringSlice(input.SecurityGroupIds),
 			},
 		},
 	}

--- a/ecs/service.go
+++ b/ecs/service.go
@@ -32,6 +32,7 @@ type Service struct {
 	Name              string
 	PendingCount      int64
 	RunningCount      int64
+	SecurityGroupIds  []string
 	TargetGroupArn    string
 	TaskDefinitionArn string
 }
@@ -191,12 +192,19 @@ func (ecs *ECS) DescribeServices(serviceArns []string) []Service {
 	}
 
 	for _, service := range resp.Services {
+		var securityGroupIds []*string
+
+		if service.NetworkConfiguration.AwsvpcConfiguration != nil {
+			securityGroupIds = service.NetworkConfiguration.AwsvpcConfiguration.SecurityGroups
+		}
+
 		s := Service{
 			Name:              aws.StringValue(service.ServiceName),
 			DesiredCount:      aws.Int64Value(service.DesiredCount),
 			PendingCount:      aws.Int64Value(service.PendingCount),
 			RunningCount:      aws.Int64Value(service.RunningCount),
 			TaskDefinitionArn: aws.StringValue(service.TaskDefinition),
+			SecurityGroupIds:  aws.StringValueSlice(securityGroupIds),
 		}
 
 		taskDefinition := ecs.DescribeTaskDefinition(aws.StringValue(service.TaskDefinition))

--- a/ecs/service.go
+++ b/ecs/service.go
@@ -35,6 +35,7 @@ type Service struct {
 	SecurityGroupIds  []string
 	TargetGroupArn    string
 	TaskDefinitionArn string
+	SubnetIds         []string
 }
 
 type Event struct {
@@ -192,10 +193,11 @@ func (ecs *ECS) DescribeServices(serviceArns []string) []Service {
 	}
 
 	for _, service := range resp.Services {
-		var securityGroupIds []*string
+		var securityGroupIds, subnetIds []*string
 
-		if service.NetworkConfiguration.AwsvpcConfiguration != nil {
-			securityGroupIds = service.NetworkConfiguration.AwsvpcConfiguration.SecurityGroups
+		if config := service.NetworkConfiguration.AwsvpcConfiguration; config != nil {
+			securityGroupIds = config.SecurityGroups
+			subnetIds = config.Subnets
 		}
 
 		s := Service{
@@ -205,6 +207,7 @@ func (ecs *ECS) DescribeServices(serviceArns []string) []Service {
 			RunningCount:      aws.Int64Value(service.RunningCount),
 			TaskDefinitionArn: aws.StringValue(service.TaskDefinition),
 			SecurityGroupIds:  aws.StringValueSlice(securityGroupIds),
+			SubnetIds:         aws.StringValueSlice(subnetIds),
 		}
 
 		taskDefinition := ecs.DescribeTaskDefinition(aws.StringValue(service.TaskDefinition))


### PR DESCRIPTION
Allow users that desired to do so to configure networking manually on services and tasks. This will allow users to use non-default VPCs and more restrictive security groups. The default behavior will remain the same - services and tasks will be placed on default subnets within the default VPC with a permissive security group.