### PR TITLE
specify cluster using environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ the AWS SDK for Go documentation.
 | --no-color | false | Disable color output |
 | --verbose | false | Verbose output |
 
+*Note that as an alternative to specifying `--cluster xyz`, the cluster can be specified by using an environment variable named, `FARGATE_CLUSTER`
+
 #### Tasks
 
 Tasks are one-time executions of your container. Instances of your task are run

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -142,17 +142,22 @@ CloudWatch Logs, and Amazon Route 53 into an easy-to-use CLI.`,
 		}
 
 		if clusterName == "" {
-			clusterName = defaultClusterName
-			ecs := ECS.New(sess, clusterName)
 
-			output.Debug("Creating default cluster [API=ecs Action=CreateCluster]")
+			clusterName = os.Getenv("FARGATE_CLUSTER")
+			if clusterName == "" {
 
-			arn, err := ecs.CreateCluster()
+				clusterName = defaultClusterName
+				ecs := ECS.New(sess, clusterName)
 
-			if err == nil {
-				output.Debug("Created default cluster [ARN=%s]", arn)
-			} else {
-				output.Fatal(err, "Could not create default cluster")
+				output.Debug("Creating default cluster [API=ecs Action=CreateCluster]")
+
+				arn, err := ecs.CreateCluster()
+
+				if err == nil {
+					output.Debug("Created default cluster [ARN=%s]", arn)
+				} else {
+					output.Fatal(err, "Could not create default cluster")
+				}
 			}
 		}
 	},


### PR DESCRIPTION
This allows the cluster to be specified using the environment variable, `FARGATE_CLUSTER`.  This is useful if you're working with the tool and running a series of commands so that you don't have to keep typing the cluster for every command.  For example:

```
export FARGATE_CLUSTER=my-cluster

fargate service info my-service
fargate service logs my-service
fargate service restart my-service
# etc
```

instead of
```
fargate --cluster my-cluster service info my-service
```