### PR TITLE
specify service using environment variable

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -1,10 +1,15 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
-const serviceLogGroupFormat = "/fargate/service/%s"
+const (
+	serviceLogGroupFormat      = "/fargate/service/%s"
+	serviceEnvironmentVariable = "FARGATE_SERVICE"
+)
 
 var serviceCmd = &cobra.Command{
 	Use:   "service",
@@ -20,4 +25,21 @@ distribute traffic amongst the tasks in your service.`,
 
 func init() {
 	rootCmd.AddCommand(serviceCmd)
+}
+
+var serviceName string
+
+//look for service first from cli args then envvars
+func setServiceName(cmd *cobra.Command, args []string) {
+	result := ""
+	if len(args) > 0 {
+		result = args[0]
+	} else {
+		result = os.Getenv(serviceEnvironmentVariable)
+	}
+	if result == "" {
+		cmd.Usage()
+		os.Exit(-1)
+	}
+	serviceName = result
 }

--- a/cmd/service_deploy.go
+++ b/cmd/service_deploy.go
@@ -27,10 +27,10 @@ container image from the current working directory and push it to Amazon ECR in
 a repository named for the task group. If the current working directory is a
 git repository, the container image will be tagged with the short ref of the
 HEAD commit. If not, a timestamp in the format of YYYYMMDDHHMMSS will be used.`,
-	Args: cobra.ExactArgs(1),
+	PreRun: setServiceName,
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ServiceDeployOperation{
-			ServiceName: args[0],
+			ServiceName: serviceName,
 			Image:       flagServiceDeployImage,
 		}
 

--- a/cmd/service_destroy.go
+++ b/cmd/service_destroy.go
@@ -19,10 +19,10 @@ var serviceDestroyCmd = &cobra.Command{
 	Long: `Destroy service
 
 In order to destroy a service, it must first be scaled to 0 running tasks.`,
-	Args: cobra.ExactArgs(1),
+	PreRun: setServiceName,
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ServiceDestroyOperation{
-			ServiceName: args[0],
+			ServiceName: serviceName,
 		}
 
 		destroyService(operation)

--- a/cmd/service_env_list.go
+++ b/cmd/service_env_list.go
@@ -13,10 +13,10 @@ type ServiceEnvListOperation struct {
 var serviceEnvListCmd = &cobra.Command{
 	Use:   "list <service-name>",
 	Short: "Show environment variables",
-	Args:  cobra.ExactArgs(1),
+	PreRun: setServiceName,
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ServiceEnvListOperation{
-			ServiceName: args[0],
+			ServiceName: serviceName,
 		}
 
 		serviceEnvList(operation)

--- a/cmd/service_env_set.go
+++ b/cmd/service_env_set.go
@@ -30,10 +30,10 @@ var serviceEnvSetCmd = &cobra.Command{
 
 At least one environment variable must be specified via the --env flag. Specify
 --env with a key=value parameter multiple times to add multiple variables.`,
-	Args: cobra.ExactArgs(1),
+	PreRun: setServiceName,
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ServiceEnvSetOperation{
-			ServiceName: args[0],
+			ServiceName: serviceName,
 		}
 
 		operation.SetEnvVars(flagServiceEnvSetEnvVars)

--- a/cmd/service_env_unset.go
+++ b/cmd/service_env_unset.go
@@ -30,10 +30,10 @@ var serviceEnvUnsetCmd = &cobra.Command{
 
 Unsets the environment variable specified via the --key flag. Specify --key with
 a key name multiple times to unset multiple variables.`,
-	Args: cobra.ExactArgs(1),
+	PreRun: setServiceName,
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ServiceEnvUnsetOperation{
-			ServiceName: args[0],
+			ServiceName: serviceName,
 		}
 
 		operation.SetKeys(flagServiceEnvUnsetKeys)

--- a/cmd/service_info.go
+++ b/cmd/service_info.go
@@ -32,10 +32,10 @@ active deployments, and environment variables.
 Deployments show active versions of your service that are running. Multiple
 deployments are shown if a service is transitioning due to a deployment or
 update to configuration such a CPU, memory, or environment variables.`,
-	Args: cobra.ExactArgs(1),
+	PreRun: setServiceName,
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ServiceInfoOperation{
-			ServiceName: args[0],
+			ServiceName: serviceName,
 		}
 
 		getServiceInfo(operation)

--- a/cmd/service_logs.go
+++ b/cmd/service_logs.go
@@ -42,15 +42,13 @@ timestamp:
 You can filter logs for specific term by passing a filter expression via the
 --filter flag. Pass a single term to search for that term, pass multiple terms
 to search for log messages that include all terms.`,
-	Args: cobra.ExactArgs(1),
-	PreRun: func(cmd *cobra.Command, args []string) {
-	},
+	PreRun: setServiceName,
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &GetLogsOperation{
-			LogGroupName: fmt.Sprintf(serviceLogGroupFormat, args[0]),
+			LogGroupName: fmt.Sprintf(serviceLogGroupFormat, serviceName),
 			Filter:       flagServiceLogsFilter,
 			Follow:       flagServiceLogsFollow,
-			Namespace:    args[0],
+			Namespace:    serviceName,
 		}
 
 		operation.AddTasks(flagServiceLogsTasks)

--- a/cmd/service_ps.go
+++ b/cmd/service_ps.go
@@ -16,12 +16,12 @@ type ServiceProcessListOperation struct {
 }
 
 var servicePsCmd = &cobra.Command{
-	Use:   "ps <service-name>",
-	Short: "List running tasks for a service",
-	Args:  cobra.ExactArgs(1),
+	Use:    "ps <service-name>",
+	Short:  "List running tasks for a service",
+	PreRun: setServiceName,
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ServiceProcessListOperation{
-			ServiceName: args[0],
+			ServiceName: serviceName,
 		}
 
 		getServiceProcessList(operation)

--- a/cmd/service_restart.go
+++ b/cmd/service_restart.go
@@ -18,10 +18,10 @@ var serviceRestartCmd = &cobra.Command{
 Creates a new set of tasks for the service and stops the previous tasks. This
 is useful if your service needs to reload data cached from an external source,
 for example.`,
-	Args: cobra.ExactArgs(1),
+	PreRun: setServiceName,
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ServiceRestartOperation{
-			ServiceName: args[0],
+			ServiceName: serviceName,
 		}
 
 		restartService(operation)

--- a/cmd/service_update.go
+++ b/cmd/service_update.go
@@ -64,10 +64,10 @@ configurations:
 | 4096            | 8192 through 30720 in 1GiB increments |
 
 At least one of --cpu or --memory must be specified.`,
-	Args: cobra.ExactArgs(1),
+	PreRun: setServiceName,
 	Run: func(cmd *cobra.Command, args []string) {
 		operation := &ServiceUpdateOperation{
-			ServiceName: args[0],
+			ServiceName: serviceName,
 			Cpu:         flagServiceUpdateCpu,
 			Memory:      flagServiceUpdateMemory,
 		}


### PR DESCRIPTION
Similar to #45, this makes the serviceName cli arg optional if specifying it via an environment variable `FARGATE_SERVICE`.

```
export FARGATE_CLUSTER=my-cluster
export FARGATE_SERVICE=my-service

fargate service ps
fargate service scale 10
fargate service info
# etc
```

instead of
```
fargate --cluster my-cluster service info my-service
```