### PR TITLE
Ability to choose scheme type for the elb #44

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ List load balancers
 ```console
 fargate lb create <load-balancer-name> --port <port-expression> [--certificate <certificate-name>]
                                        [--subnet-id <subnet-id>] [--security-group-id <security-group-id>]
+                                       [--scheme <lb-scheme>]
 ```
 
 Create a load balancer
@@ -518,6 +519,9 @@ passing the --security-group-id flag with a security group ID. To add multiple
 security groups, pass --security-group-id with a security group ID multiple
 times. If --security-group-id is omitted, a permissive security group will be
 applied to the load balancer.
+
+You can also choose the scheme type for load balancer via the --scheme flag.
+By default, load balancers are internet-facing.
 
 ##### fargate lb destroy
 

--- a/cmd/lb_create.go
+++ b/cmd/lb_create.go
@@ -12,11 +12,12 @@ import (
 type lbCreateOperation struct {
 	certificateARNs []string
 	certificateOperation
-	elbv2  elbv2.Client
-	lbType string
-	lbName string
-	output Output
-	ports  []Port
+	elbv2    elbv2.Client
+	lbType   string
+	lbScheme string
+	lbName   string
+	output   Output
+	ports    []Port
 	vpcOperation
 }
 
@@ -130,6 +131,7 @@ func (o lbCreateOperation) execute() {
 			SecurityGroupIDs: o.securityGroupIDs,
 			SubnetIDs:        o.subnetIDs,
 			Type:             o.lbType,
+			Scheme:           o.lbScheme,
 		},
 	)
 
@@ -179,7 +181,7 @@ func (o lbCreateOperation) execute() {
 }
 
 func newLBCreateOperation(
-	lbName string,
+	lbName, lbScheme string,
 	certificates, ports, securityGroupIDs, subnetIDs []string,
 	output Output,
 	acm acm.Client,
@@ -190,6 +192,7 @@ func newLBCreateOperation(
 		certificateOperation: certificateOperation{acm: acm, output: output},
 		elbv2:                elbv2,
 		lbName:               lbName,
+		lbScheme:             lbScheme,
 		output:               output,
 		vpcOperation:         vpcOperation{ec2: ec2, output: output},
 	}
@@ -265,6 +268,7 @@ applied to the load balancer.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		operation, errs := newLBCreateOperation(
 			args[0],
+			lbCreateFlags.scheme,
 			lbCreateFlags.certificates,
 			lbCreateFlags.ports,
 			lbCreateFlags.securityGroupIDs,
@@ -284,6 +288,7 @@ applied to the load balancer.`,
 	}}
 
 var lbCreateFlags struct {
+	scheme           string
 	certificates     []string
 	ports            []string
 	securityGroupIDs []string
@@ -299,6 +304,8 @@ func init() {
 		"ID of a security group to apply to the load balancer (can be specified multiple times)")
 	lbCreateCmd.Flags().StringSliceVar(&lbCreateFlags.subnetIDs, "subnet-id", []string{},
 		"ID of a subnet to place the load balancer (can be specified multiple times)")
+	lbCreateCmd.Flags().StringVarP(&lbCreateFlags.scheme, "scheme", "s", "internet-facing",
+		"Scheme of the load balancer")
 
 	lbCmd.AddCommand(lbCreateCmd)
 }

--- a/cmd/lb_create_test.go
+++ b/cmd/lb_create_test.go
@@ -681,6 +681,7 @@ func TestNewLBCreateOperation(t *testing.T) {
 
 	o, errs := newLBCreateOperation(
 		"web",
+		"internet-facing",
 		[]string{"example.com"},
 		[]string{"80", "443"},
 		[]string{"sg-abcdef"},
@@ -759,6 +760,7 @@ func TestNewLBCreateOperationDefaults(t *testing.T) {
 
 	o, errs := newLBCreateOperation(
 		"web",
+		"internet-facing",
 		[]string{},
 		[]string{"80"},
 		[]string{},
@@ -799,6 +801,7 @@ func TestNewLBCreateOperationDefaultsWithSGCreate(t *testing.T) {
 
 	o, errs := newLBCreateOperation(
 		"web",
+		"internet-facing",
 		[]string{},
 		[]string{"80"},
 		[]string{},
@@ -832,6 +835,7 @@ func TestNewLBCreateOperationNoName(t *testing.T) {
 
 	_, err := newLBCreateOperation(
 		"",
+		"internet-facing",
 		[]string{},
 		[]string{"80"},
 		[]string{"sg-abcdef"},
@@ -863,6 +867,7 @@ func TestNewLBCreateOperationNoPort(t *testing.T) {
 
 	_, err := newLBCreateOperation(
 		"web",
+		"internet-facing",
 		[]string{},
 		[]string{},
 		[]string{},
@@ -894,6 +899,7 @@ func TestNewLBCreateOperationDefaultSubnets(t *testing.T) {
 
 	_, err := newLBCreateOperation(
 		"web",
+		"internet-facing",
 		[]string{},
 		[]string{"445"},
 		[]string{},
@@ -923,6 +929,7 @@ func TestNewLBCreateOperationDescribeSubnetsError(t *testing.T) {
 
 	_, err := newLBCreateOperation(
 		"web",
+		"internet-facing",
 		[]string{},
 		[]string{"80"},
 		[]string{"sg-abcdef"},
@@ -952,6 +959,7 @@ func TestNewLBCreateOperationInvalidProtocol(t *testing.T) {
 
 	_, err := newLBCreateOperation(
 		"web",
+		"internet-facing",
 		[]string{},
 		[]string{"SMTP:25"},
 		[]string{"sg-abcdef"},
@@ -982,6 +990,7 @@ func TestNewLBCreateOperationUseDefaultSG(t *testing.T) {
 
 	o, err := newLBCreateOperation(
 		"web",
+		"internet-facing",
 		[]string{},
 		[]string{"80"},
 		[]string{},
@@ -1012,6 +1021,7 @@ func TestNewLBCreateOperationDefaultSGError(t *testing.T) {
 
 	_, errs := newLBCreateOperation(
 		"web",
+		"internet-facing",
 		[]string{},
 		[]string{"80"},
 		[]string{},
@@ -1045,6 +1055,7 @@ func TestNewLBCreateOperationCertificateError(t *testing.T) {
 
 	_, errs := newLBCreateOperation(
 		"web",
+		"internet-facing",
 		[]string{"example.com"},
 		[]string{"80", "443"},
 		[]string{"sg-abcdef"},

--- a/elbv2/load_balancer.go
+++ b/elbv2/load_balancer.go
@@ -31,6 +31,7 @@ type CreateLoadBalancerParameters struct {
 	SecurityGroupIDs []string
 	SubnetIDs        []string
 	Type             string
+	Scheme           string
 }
 
 // CreateLoadBalancer creates a new load balancer. It returns the ARN of the load balancer if it is successfully
@@ -40,6 +41,7 @@ func (elbv2 SDKClient) CreateLoadBalancer(p CreateLoadBalancerParameters) (strin
 		Name:    aws.String(p.Name),
 		Subnets: aws.StringSlice(p.SubnetIDs),
 		Type:    aws.String(p.Type),
+		Scheme:  aws.String(p.Scheme),
 	}
 
 	if p.Type == awselbv2.LoadBalancerTypeEnumApplication {

--- a/elbv2/load_balancer_test.go
+++ b/elbv2/load_balancer_test.go
@@ -133,6 +133,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 	subnetIDs := []string{"subnet-1234567"}
 	securityGroupIDs := []string{"sg-1234567"}
 	lbType := "application"
+	lbScheme := "internet-facing"
 
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
@@ -144,6 +145,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 		Subnets:        aws.StringSlice(subnetIDs),
 		SecurityGroups: aws.StringSlice(securityGroupIDs),
 		Type:           aws.String(lbType),
+		Scheme:         aws.String(lbScheme),
 	}
 	o := &awselbv2.CreateLoadBalancerOutput{
 		LoadBalancers: []*awselbv2.LoadBalancer{
@@ -156,6 +158,7 @@ func TestCreateLoadBalancer(t *testing.T) {
 		Name:             name,
 		SubnetIDs:        subnetIDs,
 		Type:             lbType,
+		Scheme:           lbScheme,
 		SecurityGroupIDs: securityGroupIDs,
 	}
 


### PR DESCRIPTION
Added --scheme flag to 'fargate lb create' command to choose either internet-facing or internal scheme.