### PR TITLE
Do not remove intermediate containers - to speed up consecutive builds…

### DIFF
--- a/docker/main.go
+++ b/docker/main.go
@@ -46,7 +46,7 @@ func (repository *Repository) Login(username, password string) {
 
 func (repository *Repository) Build(tag string) {
 	console.Debug("Building Docker image [%s]", repository.UriFor(tag))
-	console.Shell("docker build --tag %s .", repository.UriFor(tag))
+	console.Shell("docker build --rm=false --tag %s .", repository.UriFor(tag))
 
 	cmd := exec.Command("docker", "build", "--tag", repository.Uri+":"+tag, ".")
 


### PR DESCRIPTION
Since the Fargate workflow involves require repeated builds and pushes, we see that `docker` is overzealous in removing intermediate containers that are not tagged, and thus slowing the build.

It is better to tell it not to remove them (this patch) and keep them to shorten consecutive builds and pushes. Then, when we are indeed of more disk space, and leave development for a longer time, we can use `docker prune` to remove these images.

This sped up my debugging builds by far.