### PR TITLE
enable region config from profile

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -101,7 +101,11 @@ CloudWatch Logs, and Amazon Route 53 into an easy-to-use CLI.`,
 			} else if envAwsRegion != "" {
 				region = envAwsRegion
 			} else {
-				region = defaultRegion
+				if sess = session.Must(session.NewSession()); *sess.Config.Region != "" {
+					region = *sess.Config.Region
+				} else {
+					region = defaultRegion
+				}
 			}
 		}
 


### PR DESCRIPTION
`region` config in profile is currently overridden by defaultRegion (#15 related) 

**steps to reproduce:**
AWS_PROFILE=myprofile
AWS_SDK_LOAD_CONFIG=1

region other than defaultRegion set in '~/.aws/config'