### PR TITLE
added us-west-1 region

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,7 +45,7 @@ CPU (CPU Units)    Memory (MiB)
 4096               8192 through 30720 in 1GiB increments
 `)
 
-var validRegions = []string{"us-east-1", "us-east-2", "us-west-2", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "eu-central-1", "eu-west-1"}
+var validRegions = []string{"us-east-1", "us-east-2", "us-west-1", "us-west-2", "ap-southeast-1", "ap-southeast-2", "ap-northeast-1", "eu-central-1", "eu-west-1"}
 
 var (
 	clusterName string


### PR DESCRIPTION
Northern California (us-west-1) supports Fargate.
https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/
